### PR TITLE
BorderRadiusのクロスブラウザ対応

### DIFF
--- a/skroll/skroll.js
+++ b/skroll/skroll.js
@@ -7,7 +7,7 @@
  * @license      The MIT License
  * @link         https://github.com/5509/skroll
  *
- * 2011-07-12 12:27
+ * 2011-07-12 12:29
  */
 ;(function($, window, document, undefined) {
 
@@ -51,7 +51,7 @@
 			scrollBarHide     : true
 		}, option);
 
-		// 古いブラウザはcusorのdataURLは無視する
+		// 古いブラウザはcursorのdataURLは無視する
 		if ( !$.support.opacity ) {
 			this.option.cursor = {
 				grab: "move",

--- a/skroll/skroll.js
+++ b/skroll/skroll.js
@@ -7,7 +7,7 @@
  * @license      The MIT License
  * @link         https://github.com/5509/skroll
  *
- * 2011-07-12 00:09
+ * 2011-07-12 12:27
  */
 ;(function($, window, document, undefined) {
 
@@ -66,7 +66,7 @@
 		this.$bar = $("<div class='scrollbar'></div>").css({
 			position           : "absolute",
 			borderRadius       : _borderRadius,
-			WebKitBorderRadius : _borderRadius,
+			WebkitBorderRadius : _borderRadius,
 			MozBorderRadius    : _borderRadius,
 			OBorderRadius      : _borderRadius,
 			MsBorderRadius     : _borderRadius,

--- a/skroll/skroll.js
+++ b/skroll/skroll.js
@@ -68,8 +68,6 @@
 			borderRadius       : _borderRadius,
 			WebkitBorderRadius : _borderRadius,
 			MozBorderRadius    : _borderRadius,
-			OBorderRadius      : _borderRadius,
-			MsBorderRadius     : _borderRadius,
 			cursor             : this.option.cursor.grab,
 			backgroundColor    : this.option.scrollBarColor,
 			WebkitTransform    : MATRIX,


### PR DESCRIPTION
OperaとIEは最初から正式なborder-radiusに対応してるので、OBorderRadiusとMsBorderRadiusはそもそも存在してません。なのでundefinedが返ってくると思います。
というのに気づいたので削除。あとtypoがあったので修正。
